### PR TITLE
v1.2.1 Fixes

### DIFF
--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -6,13 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Lint on PHP 7.2
+      - name: Lint on PHP 8.2
         uses: firehed/lint-php-action@v1
         with:
           file-extensions: 'php, inc'
-          php-version: "7.2"
-      - name: Lint on PHP 8.1
-        uses: firehed/lint-php-action@v1
-        with:
-          file-extensions: 'php, inc'
-          php-version: "8.1"
+          php-version: "8.2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency: build
+
+jobs:
+  build:
+    runs-on: self-hosted
+
+    strategy:
+      matrix:
+        include:
+          - freebsd_version: FreeBSD-14.0-CURRENT
+            pfsense_version: 2.7
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup FreeBSD build VM
+        run: |
+          /usr/local/bin/VBoxManage controlvm ${{ matrix.freebsd_version }} poweroff || true
+          /usr/local/bin/VBoxManage snapshot ${{ matrix.freebsd_version }} restore initial
+          /usr/local/bin/VBoxManage startvm ${{ matrix.freebsd_version }} --type headless
+          sleep 5
+
+      - name: Build pfSense-pkg-saml2-auth on FreeBSD
+        run: |
+          /usr/bin/ssh -o StrictHostKeyChecking=no ${{ matrix.freebsd_version }}.jaredhendrickson.com 'sudo pkill ntpd || true && sudo ntpdate pool.ntp.org || true'
+          /usr/local/bin/python3 tools/make_package.py --host ${{ matrix.freebsd_version }}.jaredhendrickson.com --branch ${{ github.sha }} --tag ${{ github.ref_name }} --filename pfSense-${{ matrix.pfsense_version }}-pkg-saml2-auth.pkg
+
+      - name: Teardown FreeBSD build VM
+        if: "${{ always() }}"
+        run: |
+          /usr/local/bin/VBoxManage controlvm ${{ matrix.freebsd_version }} poweroff || true
+          /usr/local/bin/VBoxManage snapshot ${{matrix.freebsd_version}} restore initial
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: pfSense-${{ matrix.pfsense_version }}-pkg-saml2-auth.pkg

--- a/pfSense-pkg-saml2-auth/files/etc/inc/saml2_auth/SAML2Auth.inc
+++ b/pfSense-pkg-saml2-auth/files/etc/inc/saml2_auth/SAML2Auth.inc
@@ -328,7 +328,7 @@ class SAML2Auth {
 
         # Remove the existing package and add the new one, then og the results
         exec("pkg-static delete -y pfSense-pkg-saml2-auth", $del_cmd_out, $del_cmd_rc);
-        exec("pkg-static add ".$url, $add_cmd_out, $add_cmd_rc);
+        exec("pkg-static add ".escapeshellarg($url), $add_cmd_out, $add_cmd_rc);
         $this->__log(implode("\n", $del_cmd_out), $console);
         $this->__log(implode("\n", $add_cmd_out), $console);
 

--- a/pfSense-pkg-saml2-auth/files/etc/inc/saml2_auth/SAML2Auth.inc
+++ b/pfSense-pkg-saml2-auth/files/etc/inc/saml2_auth/SAML2Auth.inc
@@ -177,7 +177,7 @@ class SAML2Auth {
 
     public static function get_pkg_version() {
         # Pull the raw pkg info for the SAML2 auth package into an array for each line
-        $pkg_info = explode(PHP_EOL, shell_exec("pkg info pfSense-pkg-saml2-auth"));
+        $pkg_info = explode(PHP_EOL, shell_exec("pkg-static info pfSense-pkg-saml2-auth"));
 
         # Loop through each line and check the version
         foreach ($pkg_info as $pkg_line) {
@@ -327,8 +327,8 @@ class SAML2Auth {
         $this->backup_config();
 
         # Remove the existing package and add the new one, then og the results
-        exec("pkg delete -y pfSense-pkg-saml2-auth", $del_cmd_out, $del_cmd_rc);
-        exec("pkg add ".$url, $add_cmd_out, $add_cmd_rc);
+        exec("pkg-static delete -y pfSense-pkg-saml2-auth", $del_cmd_out, $del_cmd_rc);
+        exec("pkg-static add ".$url, $add_cmd_out, $add_cmd_rc);
         $this->__log(implode("\n", $del_cmd_out), $console);
         $this->__log(implode("\n", $add_cmd_out), $console);
 

--- a/pfSense-pkg-saml2-auth/files/etc/inc/saml2_auth/SAML2Auth.inc
+++ b/pfSense-pkg-saml2-auth/files/etc/inc/saml2_auth/SAML2Auth.inc
@@ -211,9 +211,7 @@ class SAML2Auth {
 
     public static function is_update_available() {
         # Check if the current version is less than the latest version
-        $curr_ver_num = intval(str_replace(".", "", self::get_pkg_version()));
-        $latest_ver_num = intval(str_replace(".", "", self::get_latest_pkg_version()));
-        return $curr_ver_num < $latest_ver_num;
+        return version_compare(self::get_pkg_version(), self::get_latest_pkg_version(), operator: "<");
     }
 
     public static function is_pkg_supported() {
@@ -339,6 +337,4 @@ class SAML2Auth {
             return false;
         }
     }
-
-
 }

--- a/pfSense-pkg-saml2-auth/files/usr/local/share/pfSense-pkg-saml2-auth/manage.php
+++ b/pfSense-pkg-saml2-auth/files/usr/local/share/pfSense-pkg-saml2-auth/manage.php
@@ -5,7 +5,7 @@ require_once("saml2_auth/SAML2Auth.inc");
 # Display the current version of pfSense and pfSense-pkg-saml2-auth
 function version() {
     # Local variables
-    $pkg_info = shell_exec("pkg info pfSense-pkg-saml2-auth").PHP_EOL;
+    $pkg_info = shell_exec("pkg-static info pfSense-pkg-saml2-auth").PHP_EOL;
     $pkg_info = explode(PHP_EOL, $pkg_info);
     $pf_ver_line = [str_replace(PHP_EOL, "", "pfSense Version: ".SAML2Auth::get_pfsense_version(true))];
     array_splice($pkg_info, 3, 0, $pf_ver_line);

--- a/pfSense-pkg-saml2-auth/files/usr/local/www/saml2_auth/update/index.php
+++ b/pfSense-pkg-saml2-auth/files/usr/local/www/saml2_auth/update/index.php
@@ -38,7 +38,7 @@ $curr_ver_msg = (SAML2Auth::is_update_available()) ? " - Update available" : " -
 # On POST, start the update process
 if ($_POST["confirm"] and !empty($_POST["version"])) {
     # Start the update process in the background and print notice
-    shell_exec("nohup pfsense-saml2 update ".$_POST["version"]." > /dev/null &");
+    shell_exec("nohup pfsense-saml2 update ".escapeshellarg($_POST["version"])." > /dev/null &");
     print_apply_result_box(0, "\nSAML2 package update process has started and is running in the background. Check back in a few minutes.");
 }
 

--- a/tools/make_package.py
+++ b/tools/make_package.py
@@ -23,6 +23,9 @@ import subprocess
 import sys
 import jinja2
 
+REPO_OWNER = "jaredhendrickson13"
+REPO_NAME = "pfsense-saml2-auth"
+
 
 class MakePackage:
     """Class that groups together variables and methods required to build the pfSense-pkg-saml2-auth FreeBSD package."""
@@ -102,13 +105,13 @@ class MakePackage:
         # Automate the process to pull, install dependencies, build and retrieve the package on a remote host
         build_cmds = [
             "mkdir -p ~/build/",
-            "rm -rf ~/build/pfsense-saml2-auth",
-            "git clone https://github.com/jaredhendrickson13/pfsense-saml2-auth.git ~/build/pfsense-saml2-auth/",
-            "git -C ~/build/pfsense-saml2-auth checkout " + self.args.branch,
-            "composer install --working-dir ~/build/pfsense-saml2-auth",
-            "rm -rf ~/build/pfsense-saml2-auth/vendor/composer && rm ~/build/pfsense-saml2-auth/vendor/autoload.php",
-            "cp -r ~/build/pfsense-saml2-auth/vendor/* ~/build/pfsense-saml2-auth/pfSense-pkg-saml2-auth/files/etc/inc/",
-            f"python3 ~/build/pfsense-saml2-auth/tools/make_package.py --tag {self.args.tag}"
+            f"rm -rf ~/build/{REPO_NAME}",
+            f"git clone https://github.com/{REPO_OWNER}/{REPO_NAME}.git ~/build/{REPO_NAME}/",
+            f"git -C ~/build/{REPO_NAME} checkout " + self.args.branch,
+            f"composer install --working-dir ~/build/{REPO_NAME}",
+            f"rm -rf ~/build/{REPO_NAME}/vendor/composer && rm ~/build/{REPO_NAME}/vendor/autoload.php",
+            f"cp -r ~/build/{REPO_NAME}/vendor/* ~/build/{REPO_NAME}/pfSense-pkg-saml2-auth/files/etc/inc/",
+            f"python3 ~/build/{REPO_NAME}/tools/make_package.py --tag {self.args.tag}"
         ]
 
         # Run each command and exit on bad status if failure
@@ -118,9 +121,10 @@ class MakePackage:
                 sys.exit(1)
 
         # Retrieve the built package
-        src = "{u}@{h}:~/build/pfsense-saml2-auth/pfSense-pkg-saml2-auth/work/pkg/pfSense-pkg-saml2-auth-{v}{r}.pkg"
+        src = "{u}@{h}:~/build/{rn}/pfSense-pkg-saml2-auth/work/pkg/pfSense-pkg-saml2-auth-{v}{r}.pkg"
         src = src.format(
             u=self.args.username,
+            rn=REPO_NAME,
             h=self.args.host,
             v=self.port_version,
             r="_" + self.port_revision if self.port_revision != "0" else ""

--- a/tools/templates/Makefile.j2
+++ b/tools/templates/Makefile.j2
@@ -12,6 +12,7 @@ COMMENT=pfSense SAML2 Authentication package
 LICENSE=APACHE20
 NO_BUILD=yes
 NO_MTREE=yes
+NO_ARCH=yes
 SUB_FILES=pkg-install pkg-deinstall
 SUB_LIST=PORTNAME=${PORTNAME}
 


### PR DESCRIPTION
### Fixes
- Changes internal `pkg` calls to use `pkg-static` in case `pkg` is updated and stuck in a bad state.
- Prevents package builds from enforcing specific architecture during install.
- Escapes variable values passed into `exec` and `shell_exec` calls.
- Fixes version comparisons when checking for available updates.

### CI/CD
- Integrates automated release workflow.