### PR TITLE
fix: populate saml group privs in get_user_privileges()

### DIFF
--- a/pfSense-pkg-saml2-auth/files/etc/inc/saml2_auth/overrides/2.7.0-RELEASE/auth.inc
+++ b/pfSense-pkg-saml2-auth/files/etc/inc/saml2_auth/overrides/2.7.0-RELEASE/auth.inc
@@ -380,6 +380,13 @@ function get_user_privileges(& $user) {
         }
     }
 
+    # Added by pfSense-pkg-saml2-auth - set SAML2 user's group assignments as specified by the SAML2 assertion
+    if ($_SESSION["authsource"] === "SAML2") {
+        require_once("saml2_auth/SAML2Auth.inc");
+        $pkg_conf = SAML2Auth::get_package_config()[1];
+        $allowed_groups = $_SESSION["saml2_user_data"][$pkg_conf["idp_groups_attribute"]];
+    }
+
     if (empty($allowed_groups)) {
         $allowed_groups = local_user_get_groups($user, true);
     }


### PR DESCRIPTION
- Fixes an issue where non-page based privileges were not assigned to members of the SAML group. #25 